### PR TITLE
only fetch topic data that are part of the consumer groupId (10 times faster)

### DIFF
--- a/src/main/java/kafdrop/controller/ConsumerController.java
+++ b/src/main/java/kafdrop/controller/ConsumerController.java
@@ -37,11 +37,8 @@ public final class ConsumerController {
 
   @RequestMapping("/{groupId:.+}")
   public String consumerDetail(@PathVariable("groupId") String groupId, Model model) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopicsWithOffsets();
-    final var consumer = kafkaMonitor.getConsumers(topicVos)
-        .stream()
-        .filter(c -> c.getGroupId().equals(groupId))
-        .findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+
     model.addAttribute("consumer", consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId)));
     return "consumer-detail";
   }
@@ -53,11 +50,8 @@ public final class ConsumerController {
   })
   @GetMapping(path = "/{groupId:.+}", produces = MediaType.APPLICATION_JSON_VALUE)
   public @ResponseBody ConsumerVO getConsumer(@PathVariable("groupId") String groupId) throws ConsumerNotFoundException {
-    final var topicVos = kafkaMonitor.getTopics();
-    final var consumer = kafkaMonitor.getConsumers(topicVos)
-        .stream()
-        .filter(c -> c.getGroupId().equals(groupId))
-        .findAny();
+    final var consumer = kafkaMonitor.getConsumersByGroup(groupId).stream().findAny();
+
     return consumer.orElseThrow(() -> new ConsumerNotFoundException(groupId));
   }
 }

--- a/src/main/java/kafdrop/controller/TopicController.java
+++ b/src/main/java/kafdrop/controller/TopicController.java
@@ -60,7 +60,7 @@ public final class TopicController {
     final var topic = kafkaMonitor.getTopic(topicName)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
     model.addAttribute("topic", topic);
-    model.addAttribute("consumers", kafkaMonitor.getConsumers(Collections.singleton(topic)));
+    model.addAttribute("consumers", kafkaMonitor.getConsumersByTopics(Collections.singleton(topic)));
     model.addAttribute("topicDeleteEnabled", topicDeleteEnabled);
     model.addAttribute("keyFormat", defaultKeyFormat);
     model.addAttribute("format", defaultFormat);
@@ -125,7 +125,7 @@ public final class TopicController {
   public @ResponseBody List<ConsumerVO> getConsumers(@PathVariable("name") String topicName) {
     final var topic = kafkaMonitor.getTopic(topicName)
         .orElseThrow(() -> new TopicNotFoundException(topicName));
-    return kafkaMonitor.getConsumers(Collections.singleton(topic));
+    return kafkaMonitor.getConsumersByTopics(Collections.singleton(topic));
   }
 
   /**

--- a/src/main/java/kafdrop/service/KafkaMonitor.java
+++ b/src/main/java/kafdrop/service/KafkaMonitor.java
@@ -31,8 +31,6 @@ public interface KafkaMonitor {
 
   List<TopicVO> getTopics();
 
-  List<TopicVO> getTopicsWithOffsets();
-
   /**
    * Returns messages for a given topic.
    */
@@ -46,7 +44,9 @@ public interface KafkaMonitor {
 
   ClusterSummaryVO getClusterSummary(Collection<TopicVO> topics);
 
-  List<ConsumerVO> getConsumers(Collection<TopicVO> topicVos);
+  List<ConsumerVO> getConsumersByGroup(String groupId);
+
+  List<ConsumerVO> getConsumersByTopics(Collection<TopicVO> topicVos);
 
   /**
    * Create topic


### PR DESCRIPTION
Currently the process is fetching **all** topics with its offset and consumergroup data. Then it filters the topics on if it has any offsets available for the consumer group. 

By any means we are discarding 99% of the data that we are fetching from Kaka. In my case the numer of topics consists of roughly 1200 and its showing maybe 9 topics with its data. Which means we are fetching data for 1191 topics that we don't need.

So instead of fetching all topic and offset data and then filtering down on the consumer groupId we now first fetch all offsets for the Consumer GroupId and construct a list of topics for which we need to fetch data.

This means we are now only fetching a fraction of the data and therefore are faster in loading the page.

Previous implementation
![image](https://user-images.githubusercontent.com/15804835/151876138-62337238-24b6-4942-a795-b5f81ab25303.png)

Improved implementation
![image](https://user-images.githubusercontent.com/15804835/151876089-66e92427-0230-4b78-a750-82e58dbd89e6.png)